### PR TITLE
Fixing bug: Too many event binded

### DIFF
--- a/src/remote-list.js
+++ b/src/remote-list.js
@@ -181,8 +181,10 @@
 					}
 				};
 			})();
-
-			inst.element.on({
+			
+			// Make sure we only bind event once to avoid too much bubbling
+			if (!inst.element.data('remotelist-binded')) {
+				inst.element.on({
 				'input focus': (function(){
 
 					var fn = function(){
@@ -226,7 +228,8 @@
 						return options.renderItem('<span class="option-value">'+ data.item.value +'</span>', data.item.label && '<span class="option-label">'+ data.item.label +'</span>', $.data(data.item.elem, 'optionData'));
 					}
 				}
-			})
+			}).data('remotelist-binded', true);
+			}
 		}
 	};
 


### PR DESCRIPTION
Prevent script to bind too many events into the input element which will crash browser if user is using the search input too many time.
